### PR TITLE
fix table name in native query

### DIFF
--- a/src/main/java/com/kage/wfhs/repository/UserRepository.java
+++ b/src/main/java/com/kage/wfhs/repository/UserRepository.java
@@ -30,7 +30,7 @@ public interface UserRepository extends JpaRepository<User,Long> {
                                         """)
     String findLastStaffIdByGender(@Param("gender") String gender);
 
-    @Query(value = "SELECT * FROM User WHERE staff_id = :staffId", nativeQuery = true)
+    @Query(value = "SELECT * FROM user WHERE staff_id = :staffId", nativeQuery = true)
     User findByStaffId(@Param("staffId") String staffId);
     User findByEmail(String email);
     Optional<User> findById(Long id);


### PR DESCRIPTION
In case of Native Query, we should use the exact table name in query. Right now, we are using "User" where our table name is "user" in the database. That's why facing this issue while running the app from the "main" branch.

![image](https://github.com/user-attachments/assets/56aa577b-9a42-4018-ba49-fb510c487cab)
